### PR TITLE
Add (minimal) formula for mathsat 5.6.12

### DIFF
--- a/mathsat@5.6.12.rb
+++ b/mathsat@5.6.12.rb
@@ -1,0 +1,16 @@
+class MathsatAT5612 < Formula
+  desc "Efficient Satisfiability Modulo Theories (SMT) solver"
+  homepage "http://mathsat.fbk.eu/index.html"
+  url "https://mathsat.fbk.eu/release/mathsat-5.6.12-macos.tar.gz"
+  sha256 "28fe0711bdd920217af706b07983f033470efc2ea15a4563397e1a930b75e9f5"
+
+  def install
+    # Install MathSat.
+    bin.install "bin/mathsat" => "mathsat-5.6.12"
+    include.install "include/mathsat.h" => "mathsat-5.6.12.h"
+    include.install "include/mathsatll.h" => "mathsatll-5.6.12.h"
+    include.install "include/msatexistelim.h" => "msatexistelim-5.6.12.h"
+    lib.install "lib/libmathsat.a" => "libmathsat-5.6.12.h"
+    (share/"mathsat@5.6.12").install "configurations", "examples"
+  end
+end


### PR DESCRIPTION
Due to issues with compiling `mathsatj`, I will not be supporting this version fully, for now.

Instead: 

* The main formula `mathsat` will remain on 5.6.11
* A versioned formula will be added for 5.6.12.

To avoid conflicts with the main formula, `mathsat-5.6.12` only installs the core components (executable, libraries, include files), and all installed files will be "versioned". E.g., the executable will be named `mathsat-5.6.12`. Support for Python and Java components is limited to the main formula.

I will file an issue detailing the compilation errors.
The versioned formula also installs some extra material under `share/mathsat@5.6.12`.